### PR TITLE
修复不合适的标题省略长度情况

### DIFF
--- a/src/content/Tree.css
+++ b/src/content/Tree.css
@@ -27,7 +27,6 @@
   width: 24px;
 }
 .sedationh-tree-node-content-title {
-  max-width: calc(100% - 14px - 24px);
   padding: 0 4px;
   overflow-x: hidden;
   white-space: nowrap;


### PR DESCRIPTION
fix #2 

最外面的卡盘有最大限制就够了，内部不需要再增加宽度限制了